### PR TITLE
Fix for objects not moving smoothly, and add basic haptics

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -269,6 +269,9 @@ class Game
                     // Parent the object to the transform on the laser pointer
                     this.selectionTransform!.position = new Vector3(0, 0, pickInfo.distance);
                     this.selectedObject!.setParent(this.selectionTransform);
+
+                    // Emit a 50ms, 0.5 intensity haptic pulse
+                    this.rightController?.motionController?.pulse(0.2,50);
                 }
             }
             else
@@ -280,6 +283,9 @@ class Game
                 if(this.selectedObject)
                 {
                     this.selectedObject!.setParent(null);
+
+                    // Emit a 50ms, 0.5 intensity haptic pulse
+                    this.rightController?.motionController?.pulse(0.2,50);
                 }
             }
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,8 @@ class Game
 
     private laserPointer: LinesMesh | null;
 
+    private totalJoystickY: number = 0;
+
     constructor()
     {
         // Get the canvas element 
@@ -305,6 +307,16 @@ class Game
 
             // Translate the object along the depth ray in world space
             this.selectedObject.translate(this.laserPointer!.forward, moveDistance, Space.WORLD);
+
+            // Maintain the totalJoystickY variable and emit a haptic pulse if
+            // a single unit boundry has been crossed
+            let oldTotalJoystickY = this.totalJoystickY;
+            this.totalJoystickY+=moveDistance*6;
+            if(Math.floor(this.totalJoystickY) != Math.floor(oldTotalJoystickY)) {
+                // Emit a 20ms, haptic pulse at an intensity determined by the joystick Y value
+                this.rightController?.motionController?.pulse(0.1+0.05*Math.abs(component!.axes!.y),20);
+            }
+
         }
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -272,7 +272,7 @@ class Game
                     this.selectionTransform!.position = new Vector3(0, 0, pickInfo.distance);
                     this.selectedObject!.setParent(this.selectionTransform);
 
-                    // Emit a 50ms, 0.5 intensity haptic pulse
+                    // Emit a 50ms, 0.2 intensity haptic pulse
                     this.rightController?.motionController?.pulse(0.2,50);
                 }
             }
@@ -286,7 +286,7 @@ class Game
                 {
                     this.selectedObject!.setParent(null);
 
-                    // Emit a 50ms, 0.5 intensity haptic pulse
+                    // Emit a 50ms, 0.2 intensity haptic pulse
                     this.rightController?.motionController?.pulse(0.2,50);
                 }
             }

--- a/src/index.ts
+++ b/src/index.ts
@@ -290,12 +290,12 @@ class Game
     {
         // If we have an object that is currently attached to the laser pointer
         // and the thumbstick was pushed
-        if(component?.changes.axes && this.selectedObject && this.selectedObject.parent)
+        if(this.selectedObject && this.selectedObject.parent)
         {
             // Use delta time to calculate the proper speed
             // DeltaTime is the time, in milliseconds, between 
             // the current and the last frame
-            var moveDistance = -component.axes.y * (this.engine.getDeltaTime() / 1000) * 3;
+            var moveDistance = -component!.axes.y * (this.engine.getDeltaTime() / 1000) * 3;
 
             // Translate the object along the depth ray in world space
             this.selectedObject.translate(this.laserPointer!.forward, moveDistance, Space.WORLD);


### PR DESCRIPTION
Previously when moving objects, the position of the object would only get updated when the joystick values changed.  This caused the object to stall whenever the joystick was stationary but not at (0,0), for example when the joystick was at (0,1) at the end of its movement range.  The object now moves each time the joystick values are read, even if they have not changed.

Basic haptics were also added that pulse when an object is selected or deselected, and pulse at a rate proportional to the movement speed when a selected object is being moved along the ray.